### PR TITLE
toolbox: Avoid issues with non-regular files

### DIFF
--- a/toolbox/chmod.c
+++ b/toolbox/chmod.c
@@ -129,6 +129,11 @@ int chmod_main(int argc, char **argv)
         s++;
     }
 
+    // We are using O_NONBLOCK in order to avoid issues with non-regular files,
+    // e.g. fifos. According to fifo(7), opening a FIFO for read only with
+    // O_NONBLOCK will succeed even if noone has opened on the write side yet.
+    flag |= O_NONBLOCK;
+
     for (i = 2; i < argc; i++) {
         if(((fd = open(argv[i], flag|O_RDONLY )) != -1)||((fd = open(argv[i], flag|O_WRONLY )) != -1)) {
             if (fchmod(fd, mode) < 0){

--- a/toolbox/chown.c
+++ b/toolbox/chown.c
@@ -82,6 +82,11 @@ int chown_main(int argc, char **argv)
         }
     }
 
+    // We are using O_NONBLOCK in order to avoid issues with non-regular files,
+    // e.g. fifos. According to fifo(7), opening a FIFO for read only with
+    // O_NONBLOCK will succeed even if noone has opened on the write side yet.
+    flag |= O_NONBLOCK;
+
     for (i = 2; i < argc; i++) {
         if(((fd = open(argv[i], flag|O_RDONLY)) != -1) ||((fd = open(argv[i], flag|O_WRONLY)) != -1)){
             if (fchown(fd, uid, gid) < 0){


### PR DESCRIPTION
Toolbox uses open() in order to check for existence of a file, instead
of using stat(). This breaks when using non-regular files such as FIFO,
because opening a FIFO for reading blocks until a writer is available.

Change-Id: I008d246d68f7ce56040f4b4c36e5ff4f9c34f4dc
