### PR TITLE
 healthd: increase healthd fast timer to 10mins instead of 1min

### DIFF
--- a/healthd/healthd.cpp
+++ b/healthd/healthd.cpp
@@ -36,8 +36,15 @@
 using namespace android;
 
 // Periodic chores intervals in seconds
+#ifdef QCOM_HARDWARE
+#define DEFAULT_PERIODIC_CHORES_INTERVAL_FAST (60 * 10)
+//For the designs without low battery detection,need to enable
+//the default 60*10s wakeup timer to periodic check.
+#define DEFAULT_PERIODIC_CHORES_INTERVAL_SLOW -1
+#else
 #define DEFAULT_PERIODIC_CHORES_INTERVAL_FAST (60 * 1)
 #define DEFAULT_PERIODIC_CHORES_INTERVAL_SLOW (60 * 10)
+#endif
 
 static struct healthd_config healthd_config = {
     .periodic_chores_interval_fast = DEFAULT_PERIODIC_CHORES_INTERVAL_FAST,


### PR DESCRIPTION
healthd 1 min wakeups are causing significant power impact
during static display use case. so increasing the timer to 10min.

Change-Id: If7a514e4152789144242e198175918b6687c3bcf

healthd: Disable the RTC wakeup timer

The timer is used here to avoid battery drained to zero. But the periodic
wakeup during suspend should not be needed as MSM PMIC already support
that by trigger interrupt to avoid the critical low battery situation.
This will save more power. And if the design is not support HW interrupt
of low battery, need to enable the timer to periodic check.

Change-Id: I040b4bc8548dc59b5e7cacb9a5a8a3557604f458
