### PR TITLE
System/core: Start qrng daemon upon power up

### DIFF
--- a/rootdir/ueventd.rc
+++ b/rootdir/ueventd.rc
@@ -6,7 +6,7 @@
 /dev/random               0666   root       root
 /dev/urandom              0666   root       root
 # Make HW RNG readable by group system to let EntropyMixer read it.
-/dev/hw_random            0440   root       system
+/dev/hw_random            0660   system     system
 /dev/ashmem               0666   root       root
 /dev/binder               0666   root       root
 


### PR DESCRIPTION
1. Set root permissions to qrng daemon upon powerup
2. Drop all permissions except few, just enough to make ioctl calls

Permission for hardware random device is changed in
this gerrit (part of Point 1(above))

Change-Id: Ibf58b7212ba1ec532de9d461266081f3ac4395e3
Signed-off-by: Hariprasad Dhalinarasimha hnamgund@codeaurora.org
