### PR TITLE
fastboot: Add missing USB ID

### DIFF
--- a/fastboot/fastboot.c
+++ b/fastboot/fastboot.c
@@ -224,7 +224,8 @@ int match_fastboot_with_serial(usb_ifc_info *info, const char *local_serial)
        (info->dev_vendor != 0x2314) &&  // INQ Mobile
        (info->dev_vendor != 0x0b05) &&  // Asus
        (info->dev_vendor != 0x0bb4) &&  // HTC
-       (info->dev_vendor != 0x0421))    // Nokia
+       (info->dev_vendor != 0x0421) &&  // Nokia
+       (info->dev_vendor != 0x1ebf))    // Coolpad
             return -1;
     if(info->ifc_class != 0xff) return -1;
     if(info->ifc_subclass != 0x42) return -1;


### PR DESCRIPTION
Change-Id: I1616e9e6a57652aa919f979833c0e19479343966
