### PR TITLE
adb/fastboot: Support SuperSpeed USB devices

### DIFF
--- a/adb/usb_linux.c
+++ b/adb/usb_linux.c
@@ -237,6 +237,21 @@ static void find_usb_device(const char *base,
                             // looks like ADB...
                         ep1 = (struct usb_endpoint_descriptor *)bufptr;
                         bufptr += USB_DT_ENDPOINT_SIZE;
+
+                        // USB3 devices are required to have superspeed
+                        // companion descriptors. They aren't needed to
+                        // locate the target so just skip them.
+                        //
+                        // When using the Android build environment, the old
+                        // ch9.h header from the prebuilts directory for the
+                        // host does not contain superspeed definitions.
+#ifndef USB_DT_SS_EP_COMP_SIZE
+#define USB_DT_SS_EP_COMP_SIZE      6
+#endif
+                        if (device->bcdUSB >= 0x0300) {
+                            bufptr += USB_DT_SS_EP_COMP_SIZE;
+                        }
+
                         ep2 = (struct usb_endpoint_descriptor *)bufptr;
                         bufptr += USB_DT_ENDPOINT_SIZE;
 

--- a/fastboot/usb_linux.c
+++ b/fastboot/usb_linux.c
@@ -225,6 +225,21 @@ static int filter_usb_device(int fd, char *ptr, int len, int writable,
             } else {
                 out = ept->bEndpointAddress;
             }
+
+            // USB3 devices are required to have superspeed companion
+            // descriptors. They aren't needed to locate the target
+            // so just skip them.
+            //
+            // When using the Android build environment, the old ch9.h
+            // header from the prebuilts directory for the host does
+            // not contain superspeed-related definitions.
+#ifndef USB_DT_SS_EP_COMP_SIZE
+#define USB_DT_SS_EP_COMP_SIZE      6
+#endif
+            if (dev->bcdUSB >= 0x0300) {
+                len -= USB_DT_SS_EP_COMP_SIZE;
+                ptr += USB_DT_SS_EP_COMP_SIZE;
+            }
         }
 
         info.has_bulk_in = (in != -1);


### PR DESCRIPTION
When enumerating USB 3.0 devices, a 6-byte SuperSpeed companion
descriptor follows each standard descriptor. The ADB and Fastboot
Linux clients currently fail to interpret these additional
descriptors and simply bail. Fix this by skipping over them.

Change-Id: I254dad8ed81e8de74a4fac36e8ce54b5da9715fe
