### PR TITLE
init: Increase the buffer for /proc/cpuinfo for ocata cores.

### DIFF
--- a/init/util.c
+++ b/init/util.c
@@ -405,14 +405,14 @@ void open_devnull_stdio(void)
 
 void get_hardware_name(char *hardware, unsigned int *revision)
 {
-    char data[1024];
+    char data[4096];
     int fd, n;
     char *x, *hw, *rev;
 
     fd = open("/proc/cpuinfo", O_RDONLY);
     if (fd < 0) return;
 
-    n = read(fd, data, 1023);
+    n = read(fd, data, sizeof(data) - 1);
     close(fd);
     if (n < 0) return;
 


### PR DESCRIPTION
The data buffer is too small to parse the hardware name of octa cores.
This results in an empty property for ro.hardware.

Change-Id: I4dab37bccfba4d74cc3f041ffcd38c887488a39d
Signed-off-by: Andreas Schneider asn@cryptomilk.org
