### PR TITLE
libutils: Properly #ifdef NEEDS_VECTORIMPL_SYMBOLS

### DIFF
--- a/include/utils/VectorImpl.h
+++ b/include/utils/VectorImpl.h
@@ -106,7 +106,7 @@ protected:
     virtual void            do_move_forward(void* dest, const void* from, size_t num) const = 0;
     virtual void            do_move_backward(void* dest, const void* from, size_t num) const = 0;
 
-#if NEEDS_VECTORIMPL_SYMBOLS
+#ifdef NEEDS_VECTORIMPL_SYMBOLS
     // take care of FBC...
     virtual void            reservedVectorImpl1();
     virtual void            reservedVectorImpl2();
@@ -168,7 +168,7 @@ public:
 protected:
     virtual int             do_compare(const void* lhs, const void* rhs) const = 0;
 
-#if NEEDS_VECTORIMPL_SYMBOLS
+#ifdef NEEDS_VECTORIMPL_SYMBOLS
     // take care of FBC...
     virtual void            reservedSortedVectorImpl1();
     virtual void            reservedSortedVectorImpl2();

--- a/libutils/VectorImpl.cpp
+++ b/libutils/VectorImpl.cpp
@@ -518,7 +518,7 @@ void VectorImpl::_do_move_backward(void* dest, const void* from, size_t num) con
     do_move_backward(dest, from, num);
 }
 
-#if NEEDS_VECTORIMPL_SYMBOLS
+#ifdef NEEDS_VECTORIMPL_SYMBOLS
 void VectorImpl::reservedVectorImpl1() { }
 void VectorImpl::reservedVectorImpl2() { }
 void VectorImpl::reservedVectorImpl3() { }
@@ -644,7 +644,7 @@ ssize_t SortedVectorImpl::remove(const void* item)
     return i;
 }
 
-#if NEEDS_VECTORIMPL_SYMBOLS
+#ifdef NEEDS_VECTORIMPL_SYMBOLS
 void SortedVectorImpl::reservedSortedVectorImpl1() { };
 void SortedVectorImpl::reservedSortedVectorImpl2() { };
 void SortedVectorImpl::reservedSortedVectorImpl3() { };


### PR DESCRIPTION
- Compile error might occur otherwise

Change-Id: I982e5f72ea4e84594e415394cceed44f90045526
(cherry picked from commit 1ff785445828a9a40138d67e1de2a4fbae9680e9)
