### PR TITLE
add the pre-recovery service

### DIFF
--- a/include/private/android_filesystem_config.h
+++ b/include/private/android_filesystem_config.h
@@ -293,6 +293,7 @@ static const struct fs_path_config android_files[] = {
     /* the following files have enhanced capabilities and ARE included in user builds. */
     { 00750, AID_ROOT,      AID_SHELL,     (1 << CAP_SETUID) | (1 << CAP_SETGID), "system/bin/run-as" },
 
+    { 00750, AID_ROOT,      AID_ROOT,      0, "system/bin/uncrypt" },
     { 00755, AID_ROOT,      AID_SHELL,     0, "system/bin/*" },
     { 00755, AID_ROOT,      AID_ROOT,      0, "system/lib/valgrind/*" },
     { 00755, AID_ROOT,      AID_SHELL,     0, "system/xbin/*" },

--- a/init/property_service.c
+++ b/init/property_service.c
@@ -122,6 +122,7 @@ struct {
 } control_perms[] = {
     { "dumpstate",AID_SHELL, AID_LOG },
     { "ril-daemon",AID_RADIO, AID_RADIO },
+    { "pre-recovery", AID_SYSTEM, AID_SYSTEM },
 #ifdef CONTROL_PERMS_APPEND
 CONTROL_PERMS_APPEND
 #endif

--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -610,3 +610,8 @@ service mdnsd /system/bin/mdnsd
     socket mdnsd stream 0660 mdnsr inet
     disabled
     oneshot
+
+service pre-recovery /system/bin/uncrypt
+    class main
+    disabled
+    oneshot


### PR DESCRIPTION
Add a service called "pre-recovery" which is normally stopped but can
be started by the system server when we want to go into recovery.  It
will do any preparation needed (currently needed to handle update
packages that reside on an encrypted /data partition) and then set
sys.powerctl when it's ready to actually reboot.

Bug: 12188746
Change-Id: I894a4cb200395a0f6d7fe643ed4c2ac0a45d2052
