### PR TITLE
android_reboot: execute recovery pre command while rw mounted

### DIFF
--- a/libcutils/android_reboot.c
+++ b/libcutils/android_reboot.c
@@ -110,9 +110,6 @@ int android_reboot(int cmd, int flags UNUSED, char *arg)
     int ret = 0;
     int reason = -1;
 
-    sync();
-    remount_ro();
-
 #ifdef RECOVERY_PRE_COMMAND
     if (cmd == (int) ANDROID_RB_RESTART2) {
         if (arg && strlen(arg) > 0) {
@@ -122,6 +119,9 @@ int android_reboot(int cmd, int flags UNUSED, char *arg)
         }
     }
 #endif
+
+    sync();
+    remount_ro();
 
     switch (cmd) {
         case ANDROID_RB_RESTART:


### PR DESCRIPTION
The TARGET_RECOVERY_PRE_COMMAND might need to write to mounted
partitions, so execute it before re-mounting everything as read-
only.

Change-Id: I66b2e81b8c05b9aa6eeddbfb589619ce53e36e2b
